### PR TITLE
Implement StableRNGs throughout tests to fix reproducibility problems in CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,8 @@ julia = "1.6"
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "MLJBase", "Test"]
+test = ["CategoricalArrays", "MLJBase", "StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-DecisionTree = "0.10"
+DecisionTree = "0.11"
 MLJModelInterface = "1.4"
 Tables = "1.6"
 julia = "1.6"

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -587,6 +587,7 @@ Train the machine with `fit!(mach, rows=...)`.
 
 - `n_iter=10`:   number of iterations of AdaBoost
 
+- `rng=Random.GLOBAL_RNG`: random number generator or seed
 
 # Operations
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -156,6 +156,7 @@ end
 
 MMI.@mlj_model mutable struct AdaBoostStumpClassifier <: MMI.Probabilistic
     n_iter::Int            = 10::(_ ≥ 1)
+    rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
 function MMI.fit(m::AdaBoostStumpClassifier, verbosity::Int, X, y)
@@ -165,8 +166,8 @@ function MMI.fit(m::AdaBoostStumpClassifier, verbosity::Int, X, y)
     classes_seen  = filter(in(unique(y)), MMI.classes(y[1]))
     integers_seen = MMI.int(classes_seen)
 
-    stumps, coefs = DT.build_adaboost_stumps(yplain, Xmatrix,
-                                             m.n_iter)
+    stumps, coefs =
+        DT.build_adaboost_stumps(yplain, Xmatrix, m.n_iter, rng=m.rng)
     cache  = nothing
     report = NamedTuple()
     return (stumps, coefs, classes_seen, integers_seen), cache, report

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,9 @@ fit!(m)
 
 N = 10
 function reproducibility(model, X, y, loss)
-    model.n_subfeatures = 1
+    if !(model isa AdaBoostStumpClassifier)
+        model.n_subfeatures = 1
+    end
     mach = machine(model, X, y)
     train, test = partition(eachindex(y), 0.7)
     errs = map(1:N) do i
@@ -140,6 +142,7 @@ end
     for model in [
         DecisionTreeClassifier(),
         RandomForestClassifier(),
+        AdaBoostStumpClassifier(),
     ]
         @test reproducibility(model, X, y, loss)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,11 +122,11 @@ fit!(m)
 
 N = 10
 function reproducibility(model, X, y, loss)
-    model.rng = srng()
     model.n_subfeatures = 1
     mach = machine(model, X, y)
     train, test = partition(eachindex(y), 0.7)
     errs = map(1:N) do i
+        model.rng = srng()
         fit!(mach, rows=train, force=true, verbosity=0)
         yhat = predict(mach, rows=test)
         loss(yhat, y[test]) |> mean
@@ -138,16 +138,16 @@ end
     X, y = make_blobs(rng=srng());
     loss = BrierLoss()
     for model in [
-        DecisionTreeClassifier(rng=srng()),
-        RandomForestClassifier(rng=srng()),
+        DecisionTreeClassifier(),
+        RandomForestClassifier(),
     ]
         @test reproducibility(model, X, y, loss)
     end
     X, y = make_regression(rng=srng());
     loss = LPLoss(p=2)
     for model in [
-        DecisionTreeRegressor(rng=srng()),
-        RandomForestRegressor(rng=srng()),
+        DecisionTreeRegressor(),
+        RandomForestRegressor(),
     ]
         @test reproducibility(model, X, y, loss)
     end


### PR DESCRIPTION
In this PR we:

- Add `rng` as a hyper-parameter in the `AdaBoostStumpClassifier` model
- (**testing**) Implement StableRNGs throughout testing to address observed inconsistencies in CI