### PR TITLE
Adding feature_importances to report for DecisionTree models

### DIFF
--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -456,7 +456,7 @@ Train the machine using `fit!(mach, rows=...)`.
 
 - `display_depth=5`:       max depth to show when displaying the tree
 
-- `feature_importance`:    method to use for computing feature importances
+- `feature_importance`:    method to use for computing feature importances. One of `(:impurity, :split)`
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -591,7 +591,7 @@ Train the machine with `fit!(mach, rows=...)`.
 
 - `sampling_fraction=0.7`  fraction of samples to train each tree on
 
-- `feature_importance`:    method to use for computing feature importances
+- `feature_importance`:    method to use for computing feature importances. One of `(:impurity, :split)`
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -668,7 +668,7 @@ Train the machine with `fit!(mach, rows=...)`.
 
 - `n_iter=10`:   number of iterations of AdaBoost
 
-- `feature_importance`:    method to use for computing feature importances
+- `feature_importance`:    method to use for computing feature importances. One of `(:impurity, :split)`
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -761,7 +761,7 @@ Train the machine with `fit!(mach, rows=...)`.
 - `merge_purity_threshold=1.0`: (post-pruning) merge leaves having
                            combined purity `>= merge_purity_threshold`
 
-- `feature_importance`:    method to use for computing feature importances
+- `feature_importance`:    method to use for computing feature importances. One of `(:impurity, :split)`
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -845,7 +845,7 @@ Train the machine with `fit!(mach, rows=...)`.
 
 - `sampling_fraction=0.7`  fraction of samples to train each tree on
 
-- `feature_importance`:    method to use for computing feature importances
+- `feature_importance`:    method to use for computing feature importances. One of `(:impurity, :split)`
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -130,7 +130,7 @@ function MMI.feature_importances(m::DecisionTreeClassifier, fitresult, report)
     tree = fitresult[1]
     features = fitresult[end]
     fi = feature_importance_func(tree)
-    fi_pairs = collect(Dict(zip(features, fi)))
+    fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
 
@@ -205,7 +205,7 @@ function MMI.feature_importances(m::RandomForestClassifier, fitresult, report)
     forest = fitresult[1]
     features = report.features
     fi = feature_importance_func(forest)
-    fi_pairs = collect(Dict(zip(features, fi)))
+    fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
 
@@ -272,7 +272,7 @@ function MMI.feature_importances(m::AdaBoostStumpClassifier, fitresult, report)
     coefs = fitresult[2]
     features = report.features
     fi = feature_importance_func(stumps, coefs)
-    fi_pairs = collect(Dict(zip(features, fi)))
+    fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
 
@@ -342,7 +342,7 @@ function MMI.feature_importances(m::DecisionTreeRegressor, fitresult, report)
     tree = fitresult
     features = report.features
     fi = feature_importance_func(tree)
-    fi_pairs = collect(Dict(zip(features, fi)))
+    fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
 
@@ -409,7 +409,7 @@ function MMI.feature_importances(m::RandomForestRegressor, fitresult, report)
     forest = fitresult
     features = report.features
     fi = feature_importance_func(forest)
-    fi_pairs = collect(Dict(zip(features, fi)))
+    fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -122,9 +122,9 @@ MMI.reports_feature_importances(::Type{<:DecisionTreeClassifier}) = true
 function MMI.feature_importances(m::DecisionTreeClassifier, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
-        feature_importance_func = DecisionTree.impurity_importance
+        feature_importance_func = DT.impurity_importance
     elseif m.feature_importance == :split
-        feature_importance_func = DecisionTree.split_importance
+        feature_importance_func = DT.split_importance
     end
 
     tree = fitresult[1]
@@ -197,9 +197,9 @@ MMI.reports_feature_importances(::Type{<:RandomForestClassifier}) = true
 function MMI.feature_importances(m::RandomForestClassifier, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
-        feature_importance_func = DecisionTree.impurity_importance
+        feature_importance_func = DT.impurity_importance
     elseif m.feature_importance == :split
-        feature_importance_func = DecisionTree.split_importance
+        feature_importance_func = DT.split_importance
     end
 
     forest = fitresult[1]
@@ -263,9 +263,9 @@ MMI.reports_feature_importances(::Type{<:AdaBoostStumpClassifier}) = true
 function MMI.feature_importances(m::AdaBoostStumpClassifier, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
-        feature_importance_func = DecisionTree.impurity_importance
+        feature_importance_func = DT.impurity_importance
     elseif m.feature_importance == :split
-        feature_importance_func = DecisionTree.split_importance
+        feature_importance_func = DT.split_importance
     end
 
     stumps = fitresult[1]
@@ -334,9 +334,9 @@ MMI.reports_feature_importances(::Type{<:DecisionTreeRegressor}) = true
 function MMI.feature_importances(m::DecisionTreeRegressor, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
-        feature_importance_func = DecisionTree.impurity_importance
+        feature_importance_func = DT.impurity_importance
     elseif m.feature_importance == :split
-        feature_importance_func = DecisionTree.split_importance
+        feature_importance_func = DT.split_importance
     end
 
     tree = fitresult
@@ -401,9 +401,9 @@ MMI.reports_feature_importances(::Type{<:RandomForestRegressor}) = true
 function MMI.feature_importances(m::RandomForestRegressor, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
-        feature_importance_func = DecisionTree.impurity_importance
+        feature_importance_func = DT.impurity_importance
     elseif m.feature_importance == :split
-        feature_importance_func = DecisionTree.split_importance
+        feature_importance_func = DT.split_importance
     end
 
     forest = fitresult
@@ -534,6 +534,8 @@ Train the machine using `fit!(mach, rows=...)`.
                            combined purity `>= merge_purity_threshold`
 
 - `display_depth=5`:       max depth to show when displaying the tree
+
+- `feature_importance`:    method to use for computing feature importances
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -668,6 +670,8 @@ Train the machine with `fit!(mach, rows=...)`.
 
 - `sampling_fraction=0.7`  fraction of samples to train each tree on
 
+- `feature_importance`:    method to use for computing feature importances
+
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
 
@@ -742,6 +746,8 @@ Train the machine with `fit!(mach, rows=...)`.
 # Hyper-parameters
 
 - `n_iter=10`:   number of iterations of AdaBoost
+
+- `feature_importance`:    method to use for computing feature importances
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
@@ -834,6 +840,8 @@ Train the machine with `fit!(mach, rows=...)`.
 - `merge_purity_threshold=1.0`: (post-pruning) merge leaves having
                            combined purity `>= merge_purity_threshold`
 
+- `feature_importance`:    method to use for computing feature importances
+
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 
 
@@ -915,6 +923,8 @@ Train the machine with `fit!(mach, rows=...)`.
 - `n_trees=10`:            number of trees to train
 
 - `sampling_fraction=0.7`  fraction of samples to train each tree on
+
+- `feature_importance`:    method to use for computing feature importances
 
 - `rng=Random.GLOBAL_RNG`: random number generator or seed
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -22,13 +22,6 @@ Base.show(stream::IO, c::TreePrinter) =
     print(stream, "TreePrinter object (call with display depth)")
 
 
-# # add a new variable to struct a la
-# const feature_importance_options = Dict(:impurity => DecisionTree.impurity_importance,
-#                                         :split => DecisionTree.split_importance,
-#                                      #   :permutation => DecisionTree.permutation_importance,
-#                                     )
-
-
 # # DECISION TREE CLASSIFIER
 
 # The following meets the MLJ standard for a `Model` docstring and is

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -71,9 +71,17 @@ function MMI.fit(m::DecisionTreeClassifier, verbosity::Int, X, y)
     fitresult = (tree, classes_seen, integers_seen, features)
 
     cache  = nothing
+
+    # generate feature importances for report
+    fi = DecisionTree.impurity_importance(tree)
+    fi_pairs = collect(Dict(zip(features, fi)))
+    # sort descending
+    sort!(fi_pairs, by= x->-x[2])
+
     report = (classes_seen=classes_seen,
               print_tree=TreePrinter(tree),
-              features=features)
+              features=features,
+              feature_importances=fi_pairs)
 
     return fitresult, cache, report
 end

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -129,7 +129,7 @@ function MMI.feature_importances(m::DecisionTreeClassifier, fitresult, report)
 
     tree = fitresult[1]
     features = fitresult[end]
-    fi = feature_importance_func(tree)
+    fi = feature_importance_func(tree, normalize=true)
     fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
@@ -204,7 +204,7 @@ function MMI.feature_importances(m::RandomForestClassifier, fitresult, report)
 
     forest = fitresult[1]
     features = report.features
-    fi = feature_importance_func(forest)
+    fi = feature_importance_func(forest, normalize=true)
     fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
@@ -271,7 +271,7 @@ function MMI.feature_importances(m::AdaBoostStumpClassifier, fitresult, report)
     stumps = fitresult[1]
     coefs = fitresult[2]
     features = report.features
-    fi = feature_importance_func(stumps, coefs)
+    fi = feature_importance_func(stumps, coefs, normalize=true)
     fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
@@ -341,7 +341,7 @@ function MMI.feature_importances(m::DecisionTreeRegressor, fitresult, report)
 
     tree = fitresult
     features = report.features
-    fi = feature_importance_func(tree)
+    fi = feature_importance_func(tree, normalize=true)
     fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])
@@ -408,7 +408,7 @@ function MMI.feature_importances(m::RandomForestRegressor, fitresult, report)
 
     forest = fitresult
     features = report.features
-    fi = feature_importance_func(forest)
+    fi = feature_importance_func(forest, normalize=true)
     fi_pairs = Pair.(features, fi)
     # sort descending
     sort!(fi_pairs, by= x->-x[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,8 +225,6 @@ end
         fit!(m)
         rpt = MLJBase.report(m)
         fi = MLJBase.feature_importances(model, m.fitresult, rpt)
-
-        println(fi)
         @test size(fi,1) == 3
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,7 +142,6 @@ fit!(m)
 rpt = MLJBase.report(m)
 @test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
 
-
 X, y = MLJBase.make_regression(rng=stable_rng())
 rfr = RandomForestRegressor(rng=stable_rng())
 m = machine(rfr, X, y)
@@ -184,3 +183,35 @@ end
         @test reproducibility(model, X, y, loss)
     end
 end
+
+
+# try testing model output for different feature_importance options
+# 1. :none
+X, y = make_regression(100,3; rng=stable_rng());
+dtr = DecisionTreeRegressor(feature_importance=:none, rng=stable_rng())
+rfr = RandomForestRegressor(feature_importance=:none, rng=stable_rng())
+
+m = machine(dtr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test isempty(rpt)
+
+m = machine(rfr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test isempty(rpt)
+
+
+# 2. :split
+dtr = DecisionTreeRegressor(feature_importance=:split, rng=stable_rng())
+rfr = RandomForestRegressor(feature_importance=:split, rng=stable_rng())
+
+m = machine(dtr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
+
+m = machine(rfr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,10 @@ X, y = MLJBase.make_blobs(100, 3; rng=stable_rng())
 m = machine(rfc, X, y)
 fit!(m)
 @test accuracy(predict_mode(m, X), y) > 0.95
+# check feature_importances
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
+
 
 m = machine(abs, X, y)
 fit!(m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,35 +110,10 @@ X, y = MLJBase.make_blobs(100, 3; rng=stable_rng())
 m = machine(rfc, X, y)
 fit!(m)
 @test accuracy(predict_mode(m, X), y) > 0.95
-# check feature_importances
-# rpt = MLJBase.report(m)
-# @test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
-
 
 m = machine(abs, X, y)
 fit!(m)
 @test accuracy(predict_mode(m, X), y) > 0.95
-# check feature_importances
-# rpt = MLJBase.report(m)
-# @test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
-
-
-
-
-# test DecisionTreeRegressor and RandomForestRegressor
-# X, y = make_regression(100,3; rng=stable_rng());
-# dtr = DecisionTreeRegressor(rng=stable_rng())
-# rfr = RandomForestRegressor(rng=stable_rng())
-
-# m = machine(dtr, X, y)
-# fit!(m)
-# rpt = MLJBase.report(m)
-# @test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
-
-# m = machine(rfr, X, y)
-# fit!(m)
-# rpt = MLJBase.report(m)
-# @test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
 
 X, y = MLJBase.make_regression(rng=stable_rng())
 rfr = RandomForestRegressor(rng=stable_rng())
@@ -183,7 +158,23 @@ end
 end
 
 
+@testset "feature importance defined" begin
+    for model ∈ [
+        DecisionTreeClassifier(),
+        RandomForestClassifier(),
+        AdaBoostStumpClassifier(),
+        DecisionTreeRegressor(),
+        RandomForestRegressor(),
+        ]
+
+        @test reports_feature_importances(model) == true
+    end
+end
+
+
+
 @testset "impurity importance" begin
+
     X, y = MLJBase.make_blobs(100, 3; rng=stable_rng())
 
     for model ∈ [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,28 @@ rpt = MLJBase.report(m)
 m = machine(abs, X, y)
 fit!(m)
 @test accuracy(predict_mode(m, X), y) > 0.95
+# check feature_importances
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
+
+
+
+
+# test DecisionTreeRegressor and RandomForestRegressor
+X, y = make_regression(100,3; rng=stable_rng());
+dtr = DecisionTreeRegressor(rng=stable_rng())
+rfr = RandomForestRegressor(rng=stable_rng())
+
+m = machine(dtr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
+
+m = machine(rfr, X, y)
+fit!(m)
+rpt = MLJBase.report(m)
+@test size(rpt.feature_importances, 1) == 3  # make sure we get an importance for each feature
+
 
 X, y = MLJBase.make_regression(rng=stable_rng())
 rfr = RandomForestRegressor(rng=stable_rng())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,10 +41,13 @@ yyhat = predict_mode(baretree, fitresult, MLJBase.selectrows(X, 1:3))
 @test MLJBase.classes(yyhat[1]) == MLJBase.classes(y[1])
 
 # check report and fitresult fields:
-@test Set([:classes_seen, :print_tree, :features]) == Set(keys(report))
+@test Set([:classes_seen, :print_tree, :features, :feature_importances]) == Set(keys(report))
 @test Set(report.classes_seen) == Set(levels(y))
 @test report.print_tree(2) === nothing # :-(
 @test report.features == [:sepal_length, :sepal_width, :petal_length, :petal_width]
+# check feature_importances
+@test size(report.features,1) == size(report.feature_importances, 1)
+
 fp = fitted_params(baretree, fitresult)
 @test Set([:tree, :encoding, :features]) == Set(keys(fp))
 @test fp.features == report.features


### PR DESCRIPTION
This update adds feature_importances to the report for each model from DecisionTrees.jl using the `impurity_importance` function. I've followed the same output format as the feature_importances from EvoTrees.jl and added a simple test for each method to runtests.jl. 