### PR TITLE
MLJ model interface compat fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DecisionTree = "0.11"
-MLJModelInterface = "1.4"
+MLJModelInterface = "1.5"
 Tables = "1.6"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJDecisionTreeInterface"
 uuid = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"


### PR DESCRIPTION
The feature importance feature added in last release requires MLJModelInterface ^1.5, but this was left at ^1.4

To do after this PR is merged and 0.2.5 is released:

- [x] yank MLJDecisionTreeInterface 0.2.4 from registry