### PR TITLE
Bump DecisionTree.jl to 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJDecisionTreeInterface"
 uuid = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.5"
+version = "0.3.0"
 
 [deps]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-DecisionTree = "0.11"
+DecisionTree = "0.12"
 MLJModelInterface = "1.5"
 Tables = "1.6"
 julia = "1.6"


### PR DESCRIPTION
Let's drop support for `DecisionTree` 0.11 so that people don't fall back to the less accurate version (https://github.com/JuliaAI/DecisionTree.jl/issues/194) when they use MLJDecisionTreeInterface 0.3?