### PR TITLE
Add a data front-end 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "StableRNGs", "Test"]
+test = ["MLJBase", "MLJTestInterface", "StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.3.0"
 
 [deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -16,10 +17,9 @@ Tables = "1.6"
 julia = "1.6"
 
 [extras]
-CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "MLJBase", "StableRNGs", "Test"]
+test = ["MLJBase", "StableRNGs", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MLJ <> DecisionTree.jl
+# DecisionTree.jl
 
-Repository implementing MLJ interface for 
+Repository implementing the MLJ model interface for 
 [DecisionTree](https://github.com/bensadeghi/DecisionTree.jl) models.
 
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -4,6 +4,7 @@ import MLJModelInterface
 using MLJModelInterface.ScientificTypesBase
 import DecisionTree
 import Tables
+using CategoricalArrays
 
 using Random
 import Random.GLOBAL_RNG
@@ -21,13 +22,13 @@ end
 Base.show(stream::IO, c::TreePrinter) =
     print(stream, "TreePrinter object (call with display depth)")
 
+function classes(y)
+    p = CategoricalArrays.pool(y)
+    [p[i] for i in 1:length(p)]
+end
 
 # # DECISION TREE CLASSIFIER
 
-# The following meets the MLJ standard for a `Model` docstring and is
-# created without the use of interpolation so it can be used a # template for authors of other MLJ model interfaces. The other
-# doc-strings, defined later, are generated using the `doc_header`
-# utility to automatically generate the header, another option.
 MMI.@mlj_model mutable struct DecisionTreeClassifier <: MMI.Probabilistic
     max_depth::Int               = (-)(1)::(_ ≥ -1)
     min_samples_leaf::Int        = 1::(_ ≥ 0)
@@ -41,19 +42,17 @@ MMI.@mlj_model mutable struct DecisionTreeClassifier <: MMI.Probabilistic
     rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
-function MMI.fit(m::DecisionTreeClassifier, verbosity::Int, X, y)
-    schema = Tables.schema(X)
-    Xmatrix = MMI.matrix(X)
-    yplain  = MMI.int(y)
+function MMI.fit(
+    m::DecisionTreeClassifier,
+    verbosity::Int,
+    Xmatrix,
+    yplain,
+    features,
+    classes,
+    )
 
-    if schema === nothing
-        features = [Symbol("x$j") for j in 1:size(Xmatrix, 2)]
-    else
-        features = schema.names |> collect
-    end
-
-    classes_seen  = filter(in(unique(y)), MMI.classes(y[1]))
-    integers_seen = MMI.int(classes_seen)
+    integers_seen = unique(yplain)
+    classes_seen  = MMI.decoder(classes)(integers_seen)
 
     tree = DT.build_tree(yplain, Xmatrix,
                          m.n_subfeatures,
@@ -70,40 +69,26 @@ function MMI.fit(m::DecisionTreeClassifier, verbosity::Int, X, y)
     fitresult = (tree, classes_seen, integers_seen, features)
 
     cache  = nothing
-    report = (classes_seen=classes_seen,
-              print_tree=TreePrinter(tree),
-              features=features,
-              )
+    report = (
+        classes_seen=classes_seen,
+        print_tree=TreePrinter(tree),
+        features=features,
+    )
     return fitresult, cache, report
 end
 
-function get_encoding(classes_seen)
-    a_cat_element = classes_seen[1]
-    return Dict(MMI.int(c) => c for c in MMI.classes(a_cat_element))
-end
+get_encoding(classes_seen) = Dict(MMI.int(c) => c for c in classes(classes_seen))
 
 MMI.fitted_params(::DecisionTreeClassifier, fitresult) =
     (tree=fitresult[1],
      encoding=get_encoding(fitresult[2]),
      features=fitresult[4])
 
-function smooth(scores, smoothing)
-    iszero(smoothing) && return scores
-    threshold = smoothing / size(scores, 2)
-    # clip low values
-    scores[scores .< threshold] .= threshold
-    # normalize
-    return scores ./ sum(scores, dims=2)
-end
-
 function MMI.predict(m::DecisionTreeClassifier, fitresult, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
     tree, classes_seen, integers_seen = fitresult
     # retrieve the predicted scores
-    scores = DT.apply_tree_proba(tree, Xmatrix, integers_seen)
-
-    # return vector of UF
-    return MMI.UnivariateFinite(classes_seen, scores)
+    scores = DT.apply_tree_proba(tree, Xnew, integers_seen)
+    MMI.UnivariateFinite(classes_seen, scores)
 end
 
 MMI.reports_feature_importances(::Type{<:DecisionTreeClassifier}) = true
@@ -123,19 +108,17 @@ MMI.@mlj_model mutable struct RandomForestClassifier <: MMI.Probabilistic
     rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
-function MMI.fit(m::RandomForestClassifier, verbosity::Int, X, y)
-    schema = Tables.schema(X)
-    Xmatrix = MMI.matrix(X)
-    yplain  = MMI.int(y)
+function MMI.fit(
+    m::RandomForestClassifier,
+    verbosity::Int,
+    Xmatrix,
+    yplain,
+    features,
+    classes,
+    )
 
-    if schema === nothing
-        features = [Symbol("x$j") for j in 1:size(Xmatrix, 2)]
-    else
-        features = schema.names |> collect
-    end
-
-    classes_seen  = filter(in(unique(y)), MMI.classes(y[1]))
-    integers_seen = MMI.int(classes_seen)
+    integers_seen = unique(yplain)
+    classes_seen  = MMI.decoder(classes)(integers_seen)
 
     forest = DT.build_forest(yplain, Xmatrix,
                              m.n_subfeatures,
@@ -156,10 +139,9 @@ end
 MMI.fitted_params(::RandomForestClassifier, (forest,_)) = (forest=forest,)
 
 function MMI.predict(m::RandomForestClassifier, fitresult, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
     forest, classes_seen, integers_seen = fitresult
-    scores = DT.apply_forest_proba(forest, Xmatrix, integers_seen)
-    return MMI.UnivariateFinite(classes_seen, scores)
+    scores = DT.apply_forest_proba(forest, Xnew, integers_seen)
+    MMI.UnivariateFinite(classes_seen, scores)
 end
 
 MMI.reports_feature_importances(::Type{<:RandomForestClassifier}) = true
@@ -173,20 +155,17 @@ MMI.@mlj_model mutable struct AdaBoostStumpClassifier <: MMI.Probabilistic
     rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
-function MMI.fit(m::AdaBoostStumpClassifier, verbosity::Int, X, y)
-    schema = Tables.schema(X)
-    Xmatrix = MMI.matrix(X)
-    yplain  = MMI.int(y)
+function MMI.fit(
+    m::AdaBoostStumpClassifier,
+    verbosity::Int,
+    Xmatrix,
+    yplain,
+    features,
+    classes,
+    )
 
-    if schema === nothing
-        features = [Symbol("x$j") for j in 1:size(Xmatrix, 2)]
-    else
-        features = schema.names |> collect
-    end
-
-
-    classes_seen  = filter(in(unique(y)), MMI.classes(y[1]))
-    integers_seen = MMI.int(classes_seen)
+    integers_seen = unique(yplain)
+    classes_seen  = MMI.decoder(classes)(integers_seen)
 
     stumps, coefs =
         DT.build_adaboost_stumps(yplain, Xmatrix, m.n_iter, rng=m.rng)
@@ -201,10 +180,13 @@ MMI.fitted_params(::AdaBoostStumpClassifier, (stumps,coefs,_)) =
     (stumps=stumps,coefs=coefs)
 
 function MMI.predict(m::AdaBoostStumpClassifier, fitresult, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
     stumps, coefs, classes_seen, integers_seen = fitresult
-    scores = DT.apply_adaboost_stumps_proba(stumps, coefs,
-                                            Xmatrix, integers_seen)
+    scores = DT.apply_adaboost_stumps_proba(
+        stumps,
+        coefs,
+        Xnew,
+        integers_seen,
+    )
     return MMI.UnivariateFinite(classes_seen, scores)
 end
 
@@ -225,23 +207,18 @@ MMI.@mlj_model mutable struct DecisionTreeRegressor <: MMI.Deterministic
     rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
-function MMI.fit(m::DecisionTreeRegressor, verbosity::Int, X, y)
-    schema = Tables.schema(X)
-    Xmatrix = MMI.matrix(X)
+function MMI.fit(m::DecisionTreeRegressor, verbosity::Int, Xmatrix, y, features)
 
-    if schema === nothing
-        features = [Symbol("x$j") for j in 1:size(Xmatrix, 2)]
-    else
-        features = schema.names |> collect
-    end
-
-    tree    = DT.build_tree(float(y), Xmatrix,
-                            m.n_subfeatures,
-                            m.max_depth,
-                            m.min_samples_leaf,
-                            m.min_samples_split,
-                            m.min_purity_increase;
-                            rng=m.rng)
+    tree = DT.build_tree(
+        y,
+        Xmatrix,
+        m.n_subfeatures,
+        m.max_depth,
+        m.min_samples_leaf,
+        m.min_samples_split,
+        m.min_purity_increase;
+        rng=m.rng
+    )
 
     if m.post_prune
         tree = DT.prune_tree(tree, m.merge_purity_threshold)
@@ -255,10 +232,7 @@ end
 
 MMI.fitted_params(::DecisionTreeRegressor, tree) = (tree=tree,)
 
-function MMI.predict(::DecisionTreeRegressor, tree, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
-    return DT.apply_tree(tree, Xmatrix)
-end
+MMI.predict(::DecisionTreeRegressor, tree, Xnew) = DT.apply_tree(tree, Xnew)
 
 MMI.reports_feature_importances(::Type{<:DecisionTreeRegressor}) = true
 
@@ -277,25 +251,21 @@ MMI.@mlj_model mutable struct RandomForestRegressor <: MMI.Deterministic
     rng::Union{AbstractRNG,Integer} = GLOBAL_RNG
 end
 
-function MMI.fit(m::RandomForestRegressor, verbosity::Int, X, y)
-    schema = Tables.schema(X)
-    Xmatrix = MMI.matrix(X)
+function MMI.fit(m::RandomForestRegressor, verbosity::Int, Xmatrix, y, features)
 
-    if schema === nothing
-        features = [Symbol("x$j") for j in 1:size(Xmatrix, 2)]
-    else
-        features = schema.names |> collect
-    end
+    forest = DT.build_forest(
+        y,
+        Xmatrix,
+        m.n_subfeatures,
+        m.n_trees,
+        m.sampling_fraction,
+        m.max_depth,
+        m.min_samples_leaf,
+        m.min_samples_split,
+        m.min_purity_increase,
+        rng=m.rng
+    )
 
-    forest  = DT.build_forest(float(y), Xmatrix,
-                              m.n_subfeatures,
-                              m.n_trees,
-                              m.sampling_fraction,
-                              m.max_depth,
-                              m.min_samples_leaf,
-                              m.min_samples_split,
-                              m.min_purity_increase,
-                              rng=m.rng)
     cache  = nothing
     report = (features=features,)
 
@@ -304,10 +274,7 @@ end
 
 MMI.fitted_params(::RandomForestRegressor, forest) = (forest=forest,)
 
-function MMI.predict(::RandomForestRegressor, forest, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
-    return DT.apply_forest(forest, Xmatrix)
-end
+MMI.predict(::RandomForestRegressor, forest, Xnew) = DT.apply_forest(forest, Xnew)
 
 MMI.reports_feature_importances(::Type{<:RandomForestRegressor}) = true
 
@@ -327,7 +294,39 @@ const IterativeModel = Union{
     AdaBoostStumpClassifier,
 }
 
-const RandomForestModel = Union{DecisionTreeClassifier, RandomForestClassifier}
+const Classifier = Union{
+    DecisionTreeClassifier,
+    RandomForestClassifier,
+    AdaBoostStumpClassifier,
+}
+
+const Regressor = Union{
+    DecisionTreeRegressor,
+    RandomForestRegressor,
+}
+
+const RandomForestModel = Union{
+    DecisionTreeClassifier,
+    RandomForestClassifier,
+}
+
+
+# # DATA FRONT END
+
+_columnnames(X) = Tables.columnnames(Tables.columns(X)) |> collect
+
+# for fit:
+MMI.reformat(::Classifier, X, y) =
+    (Tables.matrix(X), MMI.int(y), _columnnames(X), classes(y))
+MMI.reformat(::Regressor, X, y) =
+    (Tables.matrix(X), float(y), _columnnames(X))
+MMI.selectrows(::TreeModel, I, Xmatrix, y, meta...) =
+    (view(Xmatrix, I, :), view(y, I), meta...)
+
+# for predict:
+MMI.reformat(::TreeModel, X) = (Tables.matrix(X),)
+MMI.selectrows(::TreeModel, I, Xmatrix) = (view(Xmatrix, I, :),)
+
 
 # # FEATURE IMPORTANCES
 

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -311,15 +311,38 @@ end
 
 MMI.reports_feature_importances(::Type{<:RandomForestRegressor}) = true
 
+# # ALIASES FOR TYPE UNIONS
 
-# # Feature Importances
+const TreeModel = Union{
+    DecisionTreeClassifier,
+    RandomForestClassifier,
+    AdaBoostStumpClassifier,
+    DecisionTreeRegressor,
+    RandomForestRegressor,
+}
+
+const IterativeModel = Union{
+    RandomForestClassifier,
+    RandomForestRegressor,
+    AdaBoostStumpClassifier,
+}
+
+const RandomForestModel = Union{DecisionTreeClassifier, RandomForestClassifier}
+
+# # FEATURE IMPORTANCES
 
 # get actual arguments needed for importance calculation from various fitresults.
-get_fitresult(m::Union{DecisionTreeClassifier, RandomForestClassifier}, fitresult) = (fitresult[1],)
-get_fitresult(m::Union{DecisionTreeRegressor, RandomForestRegressor}, fitresult) = (fitresult,)
+get_fitresult(
+    m::Union{DecisionTreeClassifier, RandomForestClassifier},
+    fitresult,
+) = (fitresult[1],)
+get_fitresult(
+    m::Union{DecisionTreeRegressor, RandomForestRegressor},
+    fitresult,
+) = (fitresult,)
 get_fitresult(m::AdaBoostStumpClassifier, fitresult)= (fitresult[1], fitresult[2])
 
-function MMI.feature_importances(m::Union{DecisionTreeClassifier, RandomForestClassifier, AdaBoostStumpClassifier, DecisionTreeRegressor, RandomForestRegressor}, fitresult, report)
+function MMI.feature_importances(m::TreeModel, fitresult, report)
     # generate feature importances for report
     if m.feature_importance == :impurity
         feature_importance_func = DT.impurity_importance
@@ -337,18 +360,7 @@ function MMI.feature_importances(m::Union{DecisionTreeClassifier, RandomForestCl
     return fi_pairs
 end
 
-
 # # METADATA (MODEL TRAITS)
-
-# following five lines of code are redundant if using this branch of
-# MLJModelInterface:
-# https://github.com/JuliaAI/MLJModelInterface.jl/pull/139
-
-# MMI.human_name(::Type{<:DecisionTreeClassifier}) = "CART decision tree classifier"
-# MMI.human_name(::Type{<:RandomForestClassifier}) = "CART random forest classifier"
-# MMI.human_name(::Type{<:AdaBoostStumpClassifier}) = "Ada-boosted stump classifier"
-# MMI.human_name(::Type{<:DecisionTreeRegressor}) = "CART decision tree regressor"
-# MMI.human_name(::Type{<:RandomForestRegressor}) = "CART random forest regressor"
 
 MMI.metadata_pkg.(
     (DecisionTreeClassifier, DecisionTreeRegressor,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ import CategoricalArrays.categorical
 using MLJBase
 using StableRNGs
 using Random
+using Tables
 Random.seed!(1234)
 
 stable_rng() = StableRNGs.StableRNG(123)
@@ -13,36 +14,40 @@ import DecisionTree
 using MLJDecisionTreeInterface
 
 # get some test data:
-X, y = @load_iris
+Xraw, yraw = @load_iris
+X = Tables.matrix(Xraw);
+y = int(yraw);
+_classes = MLJDecisionTreeInterface.classes(yraw)
+features = MLJDecisionTreeInterface._columnnames(Xraw)
 
 baretree = DecisionTreeClassifier(rng=stable_rng())
 
 baretree.max_depth = 1
-fitresult, cache, report = MLJBase.fit(baretree, 2, X, y);
+fitresult, cache, report = MLJBase.fit(baretree, 2, X, y, features, _classes);
 baretree.max_depth = -1 # no max depth
 fitresult, cache, report =
-    MLJBase.update(baretree, 1, fitresult, cache, X, y);
+    MLJBase.fit(baretree, 1, X, y, features, _classes);
 
 # in this case decision tree is a perfect predictor:
 yhat = MLJBase.predict_mode(baretree, fitresult, X);
-@test yhat == y
+@test int(yhat) == y
 
 # but pruning upsets this:
 baretree.post_prune = true
 baretree.merge_purity_threshold=0.1
 fitresult, cache, report =
-    MLJBase.update(baretree, 2, fitresult, cache, X, y)
+    MLJBase.fit(baretree, 2, X, y, features, _classes)
 yhat = MLJBase.predict_mode(baretree, fitresult, X);
-@test yhat != y
+@test int(yhat) != y
 yhat = MLJBase.predict(baretree, fitresult, X);
 
 # check preservation of levels:
-yyhat = predict_mode(baretree, fitresult, MLJBase.selectrows(X, 1:3))
-@test MLJBase.classes(yyhat[1]) == MLJBase.classes(y[1])
+yyhat = predict_mode(baretree, fitresult, X[1:3, :])
+@test MLJBase.classes(yyhat[1]) == MLJBase.classes(yraw)
 
 # check report and fitresult fields:
 @test Set([:classes_seen, :print_tree, :features]) == Set(keys(report))
-@test Set(report.classes_seen) == Set(levels(y))
+@test Set(report.classes_seen) == Set(levels(yraw))
 @test report.print_tree(2) === nothing # :-(
 @test report.features == [:sepal_length, :sepal_width, :petal_length, :petal_width]
 
@@ -51,16 +56,16 @@ fp = fitted_params(baretree, fitresult)
 @test fp.features == report.features
 enc = fp.encoding
 @test Set(values(enc)) == Set(["virginica", "setosa", "versicolor"])
-@test enc[MLJBase.int(y[end])] == "virginica"
+@test enc[y[end]] == "virginica"
 
 using Random: seed!
 seed!(0)
 
 n,m = 10^3, 5;
-raw_features = rand(stable_rng(), n,m);
+X = rand(stable_rng(), n,m);
+features = [:x1, :x2, :x3, :x4, :x5]
 weights = rand(stable_rng(), -1:1,m);
-labels = raw_features * weights;
-features = MLJBase.table(raw_features);
+y = X * weights;
 
 R1Tree = DecisionTreeRegressor(
     min_samples_leaf=5,
@@ -68,42 +73,46 @@ R1Tree = DecisionTreeRegressor(
     rng=stable_rng(),
 )
 R2Tree = DecisionTreeRegressor(min_samples_split=5, rng=stable_rng())
-model1, = MLJBase.fit(R1Tree,1, features, labels)
+model1, = MLJBase.fit(R1Tree,1, X, y, features)
 
-vals1 = MLJBase.predict(R1Tree,model1,features)
+vals1 = MLJBase.predict(R1Tree,model1,X)
 R1Tree.post_prune = true
-model1_prune, = MLJBase.fit(R1Tree,1, features, labels)
-vals1_prune = MLJBase.predict(R1Tree,model1_prune,features)
+model1_prune, = MLJBase.fit(R1Tree,1, X, y, features)
+vals1_prune = MLJBase.predict(R1Tree,model1_prune,X)
 @test vals1 !=vals1_prune
 
-@test DecisionTree.R2(labels, vals1) > 0.8
+@test DecisionTree.R2(y, vals1) > 0.8
 
-model2, = MLJBase.fit(R2Tree, 1, features, labels)
-vals2 = MLJBase.predict(R2Tree, model2, features)
-@test DecisionTree.R2(labels, vals2) > 0.8
+model2, = MLJBase.fit(R2Tree, 1, X, y, features)
+vals2 = MLJBase.predict(R2Tree, model2, X)
+@test DecisionTree.R2(y, vals2) > 0.8
 
 
 ## TEST ON ORDINAL FEATURES OTHER THAN CONTINUOUS
 
 N = 20
-X = (
+Xraw = (
     x1=rand(stable_rng(),N),
     x2=categorical(rand(stable_rng(), "abc", N), ordered=true),
     x3=collect(1:N),
-)
-yfinite = X.x2
-ycont = float.(X.x3)
+);
+y1 = Xraw.x2;
+y2 = float.(Xraw.x3);
 
 rgs = DecisionTreeRegressor(rng=stable_rng())
-fitresult, _, _ = MLJBase.fit(rgs, 1, X, ycont)
-@test rms(predict(rgs, fitresult, X), ycont) < 1.5
+X, y, features = MMI.reformat(rgs, Xraw, y2)
+
+fitresult, _, _ = MLJBase.fit(rgs, 1, X, y, features)
+@test rms(predict(rgs, fitresult, X), y) < 1.5
 
 clf = DecisionTreeClassifier()
-fitresult, _, _ = MLJBase.fit(clf, 1, X, yfinite)
-@test sum(predict(clf, fitresult, X) .== yfinite) == 0 # perfect prediction
+X, y, features, _classes = MMI.reformat(clf, Xraw, y1)
+
+fitresult, _, _ = MLJBase.fit(clf, 1, X, y, features, _classes)
+@test sum(predict(clf, fitresult, X) .== y1) == 0 # perfect prediction
 
 
-# --  Ensemble
+# ENSEMBLES AND INTEGRATION WITH MLJBASE MACHINES
 
 rfc = RandomForestClassifier(rng=stable_rng())
 abs = AdaBoostStumpClassifier(rng=stable_rng())
@@ -160,7 +169,6 @@ end
     end
 end
 
-
 @testset "feature importance defined" begin
     for model ∈ [
         DecisionTreeClassifier(),
@@ -173,8 +181,6 @@ end
         @test reports_feature_importances(model) == true
     end
 end
-
-
 
 @testset "impurity importance" begin
 
@@ -206,7 +212,6 @@ end
     end
 end
 
-
 @testset "split importance" begin
     X, y = MLJBase.make_blobs(100, 3; rng=stable_rng())
 
@@ -236,4 +241,4 @@ end
     end
 end
 
-
+true


### PR DESCRIPTION
This PR is in support of #40.

It add the `reformat/selectrows`  MLJModelInterface.jl [data front-end](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Implementing-a-data-front-end). It also does a bit of cleaning up and adds generic integration tests from MLJTestInterface.jl.

The other test code changes are just adaptions of the existing tests necessary because of the data front-end addition, which changes all the fit/predict signatures.

I have also locally verified that level-4 tests from MLJTestIntegration.jl also pass.

