### PR TITLE
Implement warm restart for random forest models

### DIFF
--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -150,6 +150,8 @@ function MMI.update(
     only_iterations_have_changed = MMI.is_same_except(model, old_model, :n_trees)
 
     if !only_iterations_have_changed
+        verbosity > 0 && @info "Detected a change to hyperparameters " *
+            "not restricted to `n_trees`. Recomputing $n_trees trees. "
         return MMI.fit(
             model,
             verbosity,

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -136,6 +136,11 @@ function MMI.fit(
     return (forest, classes_seen, integers_seen), cache, report
 end
 
+info_recomputing(n) = "Detected a change to hyperparameters " *
+    "not restricted to `n_trees`. Recomputing all $n trees trees. "
+info_dropping(n) =  "Dropping $n trees from the ensemble. "
+info_adding(n) = "Adding $n trees to the ensemble. "
+
 function MMI.update(
     model::RandomForestClassifier,
     verbosity::Int,
@@ -150,8 +155,7 @@ function MMI.update(
     only_iterations_have_changed = MMI.is_same_except(model, old_model, :n_trees)
 
     if !only_iterations_have_changed
-        verbosity > 0 && @info "Detected a change to hyperparameters " *
-            "not restricted to `n_trees`. Recomputing $n_trees trees. "
+        verbosity > 0 && @info info_recomputing(model.n_trees)
         return MMI.fit(
             model,
             verbosity,
@@ -166,10 +170,10 @@ function MMI.update(
     Δn_trees = model.n_trees - old_model.n_trees
     # if `n_trees` drops, then tuncate, otherwise compute more trees
     if Δn_trees < 0
-        verbosity > 0 && @info "Dropping $(-Δn_trees) trees from the forest. "
+        verbosity > 0 && @info info_dropping(-Δn_trees)
         forest = old_forest[1:model.n_trees]
     else
-        verbosity > 0 && @info "Adding $Δn_trees trees to the forest. "
+        verbosity > 0 && @info info_adding(Δn_trees)
         forest = DT.build_forest(
             old_forest,
             yplain, Xmatrix,
@@ -340,8 +344,7 @@ function MMI.update(
     only_iterations_have_changed = MMI.is_same_except(model, old_model, :n_trees)
 
     if !only_iterations_have_changed
-        verbosity > 0 && @info "Detected a change to hyperparameters " *
-            "not restricted to `n_trees`. Recomputing $n_trees trees. "
+        verbosity > 0 && @info info_recomputing(model.n_trees)
         return MMI.fit(
             model,
             verbosity,
@@ -355,10 +358,10 @@ function MMI.update(
 
     # if `n_trees` drops, then tuncate, otherwise compute more trees
     if Δn_trees < 0
-        verbosity > 0 && @info "Dropping $(-Δn_trees) trees from the forest. "
+        verbosity > 0 && @info info_dropping(-Δn_trees)
         forest = old_forest[1:model.n_trees]
     else
-        verbosity > 0 && @info "Adding $Δn_trees trees to the forest. "
+        verbosity > 0 && @info info_adding(Δn_trees)
         forest = DT.build_forest(
             old_forest,
             y,

--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -340,6 +340,8 @@ function MMI.update(
     only_iterations_have_changed = MMI.is_same_except(model, old_model, :n_trees)
 
     if !only_iterations_have_changed
+        verbosity > 0 && @info "Detected a change to hyperparameters " *
+            "not restricted to `n_trees`. Recomputing $n_trees trees. "
         return MMI.fit(
             model,
             verbosity,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,7 +286,7 @@ end
             mach.model = $M(n_trees=7, rng = stable_rng())
             @test_logs(
                 (:info, r""),
-                (:info, r"Adding 3 trees"),
+                (:info, MLJDecisionTreeInterface.info_adding(3)),
                 fit!(mach, verbosity=1),
             )
 
@@ -294,7 +294,7 @@ end
             mach.model = $M(n_trees=5, rng = stable_rng())
             @test_logs(
                 (:info, r""),
-                (:info, r"Dropping 2 trees"),
+                (:info, MLJDecisionTreeInterface.info_dropping(2)),
                 fit!(mach, verbosity=1),
             )
             forest1_5 = fitted_params(mach).forest
@@ -304,7 +304,7 @@ end
             mach.model = $M(n_trees=5, rng = stable_rng(), max_depth=1)
             @test_logs(
                 (:info, r""),
-                (:info, r"Detected"),
+                (:info, MLJDecisionTreeInterface.info_recomputing(5)),
                 fit!(mach, verbosity=1),
             )
             forest1_5_again = fitted_params(mach).forest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,12 +281,16 @@ end
             fit!(mach, verbosity=0)
             forest1_4 = fitted_params(mach).forest
             @test length(forest1_4) ==4
+
+            # increase n_trees:
             mach.model = $M(n_trees=7, rng = stable_rng())
             @test_logs(
                 (:info, r""),
                 (:info, r"Adding 3 trees"),
                 fit!(mach, verbosity=1),
             )
+
+            # decrease n_trees:
             mach.model = $M(n_trees=5, rng = stable_rng())
             @test_logs(
                 (:info, r""),
@@ -295,6 +299,16 @@ end
             )
             forest1_5 = fitted_params(mach).forest
             @test length(forest1_5) == 5
+
+            # change a different hyperparameter:
+            mach.model = $M(n_trees=5, rng = stable_rng(), max_depth=1)
+            @test_logs(
+                (:info, r""),
+                (:info, r"Detected"),
+                fit!(mach, verbosity=1),
+            )
+            forest1_5_again = fitted_params(mach).forest
+            @test length(forest1_5_again) == 5
         end |> eval
     end
 end


### PR DESCRIPTION
Closes #40.

Needs: 

- [x] #41 
- [x] https://github.com/JuliaAI/DecisionTree.jl/pull/216

I have tested locally, including `level=4`  MLJIntegration.jl tests. 

Here's a demo:

```julia
using MLJBase, MLJIteration, MLJModels

X, y = make_blobs(centers=5)

Forest = @load RandomForestClassifier pkg=DecisionTree

forest = Forest()

controls = [
    Step(5),
    Patience(3),
    TimeLimit(1/60), # one minute
    InvalidValue(),
]

iterated_forest = IteratedModel(
    forest;
    controls,
    resampling=Holdout(fraction_train=0.7),
    measure = BrierScore(),
    retrain = true, # retrain on all data after determining `n_trees`
)

mach = machine(iterated_forest, X, y) |> fit!

# [ Info: Training machine(ProbabilisticIteratedModel(model = RandomForestClassifier(max_depth = -1, …), …), …).
# [ Info: No iteration parameter specified. Using `iteration_parameter=:(n_trees)`. 
# [ Info: final loss: -0.45789090909090907
# [ Info: Stop triggered by Patience(3) stopping criterion. 
# [ Info: Retraining on all provided data. To suppress, specify `retrain=false`. 
# [ Info: Total of 50 iterations. 
# trained Machine; does not cache data
#   model: ProbabilisticIteratedModel(model = RandomForestClassifier(max_depth = -1, …), …)
#   args: 
#     1:  Source @213 ⏎ Table{AbstractVector{Continuous}}
#     2:  Source @388 ⏎ AbstractVector{Multiclass{5}}

predict(mach, selectrows(X, 1:3))

# 3-element UnivariateFiniteVector{Multiclass{5}, Int64, UInt32, Float64}:
#  UnivariateFinite{Multiclass{5}}(1=>0.04, 2=>0.96, 3=>0.0, 4=>0.0, 5=>0.0)
#  UnivariateFinite{Multiclass{5}}(1=>0.0, 2=>0.0, 3=>0.16, 4=>0.7, 5=>0.14)
#  UnivariateFinite{Multiclass{5}}(1=>0.06, 2=>0.0, 3=>0.92, 4=>0.0, 5=>0.02)

```
