### PR TITLE
Print the feature names in report.print_tree()

### DIFF
--- a/src/MLJDecisionTreeInterface.jl
+++ b/src/MLJDecisionTreeInterface.jl
@@ -15,9 +15,10 @@ const PKG = "MLJDecisionTreeInterface"
 
 struct TreePrinter{T}
     tree::T
+    features::Vector{Symbol}
 end
-(c::TreePrinter)(depth) = DT.print_tree(c.tree, depth)
-(c::TreePrinter)() = DT.print_tree(c.tree, 5)
+(c::TreePrinter)(depth) = DT.print_tree(c.tree, depth, feature_names = c.features)
+(c::TreePrinter)() = DT.print_tree(c.tree, 5, feature_names = c.features)
 
 Base.show(stream::IO, c::TreePrinter) =
     print(stream, "TreePrinter object (call with display depth)")
@@ -71,7 +72,7 @@ function MMI.fit(
     cache  = nothing
     report = (
         classes_seen=classes_seen,
-        print_tree=TreePrinter(tree),
+        print_tree=TreePrinter(tree, features),
         features=features,
     )
     return fitresult, cache, report


### PR DESCRIPTION
This commit addresses issue #23 by modifying TreePrinter struct and fit function to include the feature_names parameter.